### PR TITLE
chore: add `build_and_push` target to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ lint:
 	cd rag-core-library;make lint
 	cd admin-backend;make lint
 	cd rag-backend;make lint
-	cd document-extractor;make lint	
+	cd document-extractor;make lint
 
 update-lock:
 	cd rag-core-library;make update-lock
@@ -17,3 +17,13 @@ black:
 	cd admin-backend;black .
 	cd rag-backend;black .
 	cd document-extractor;black .
+
+IMAGE_TAG?=v1.0.0
+REGISTRY?=
+
+build_and_push:
+	docker buildx build --platform linux/amd64 -t $(REGISTRY)/rag-backend:$(IMAGE_TAG)  -f rag-backend/Dockerfile --push  .
+	docker buildx build --platform linux/amd64 -t $(REGISTRY)/admin-backend:$(IMAGE_TAG)  -f admin-backend/Dockerfile --push .
+	docker buildx build --platform linux/amd64 -t $(REGISTRY)/document-extractor:$(IMAGE_TAG)  -f document-extractor/Dockerfile --push .
+	docker buildx build --platform linux/amd64 -t $(REGISTRY)/frontend:$(IMAGE_TAG)  -f frontend/apps/chat-app/Dockerfile --push .
+	docker buildx build --platform linux/amd64 -t $(REGISTRY)/admin-frontend:$(IMAGE_TAG)  -f frontend/apps/admin-app/Dockerfile --push .


### PR DESCRIPTION
This pull request introduces a new `build_and_push` target in the `Makefile` to streamline the process of building and pushing Docker images for various components of the project. It also defines two new variables, `IMAGE_TAG` and `REGISTRY`, to allow customization of the image tags and registry.

### Additions to the `Makefile`:

* **New `build_and_push` target**: Automates the Docker build and push process for the following components:
  - `rag-backend`
  - `admin-backend`
  - `document-extractor`
  - `frontend` (chat app)
  - `admin-frontend` (admin app)

* **New variables**:
  - [`IMAGE_TAG`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R20-R29): Allows specifying the Docker image version (default: `v1.0.0`).
  - [`REGISTRY`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R20-R29): Enables setting a custom Docker registry.