### PR TITLE
fix: rename document_reference_id_get method to document_reference

### DIFF
--- a/libs/admin-api-lib/src/admin_api_lib/impl/admin_api.py
+++ b/libs/admin-api-lib/src/admin_api_lib/impl/admin_api.py
@@ -141,7 +141,7 @@ class AdminApi(BaseAdminApi):
         await file_uploader.upload_file(str(request.base_url), file)
 
     @inject
-    async def document_reference_id_get(
+    async def document_reference(
         self,
         identification: str,
         document_reference_retriever: DocumentReferenceRetriever = Depends(


### PR DESCRIPTION
This pull request includes a small change to the `admin_api.py` file. The change renames the `document_reference_id_get` method to `document_reference` to fix retrieval issue due to naming missmatch