### PR TITLE
chore: update stackit vllm settings defaults

### DIFF
--- a/libs/rag-core-lib/src/rag_core_lib/impl/settings/stackit_vllm_settings.py
+++ b/libs/rag-core-lib/src/rag_core_lib/impl/settings/stackit_vllm_settings.py
@@ -28,8 +28,8 @@ class StackitVllmSettings(BaseSettings):
         env_prefix = "STACKIT_VLLM_"
         case_sensitive = False
 
-    model: str = Field(default="cortecs/Meta-Llama-3-70B-Instruct-GPTQ-8b")
-    base_url: str = Field(default="https://ecd9b66f-15d1-4efd-a7ef-5bc90c60883f.model-serving.eu01.onSTACKIT.cloud/v1")
+    model: str = Field(default="cortecs/Llama-3.3-70B-Instruct-FP8-Dynamic")
+    base_url: str = Field(default="https://api.openai-compat.model-serving.eu01.onstackit.cloud/v1")
     api_key: str
 
     top_p: float = Field(default=0.1, title="LLM Top P")


### PR DESCRIPTION
This pull request updates the configuration settings for the `Config` class in `stackit_vllm_settings.py`. The changes involve updating the default model and base URL to align with newer specifications.

Configuration updates:

* [`libs/rag-core-lib/src/rag_core_lib/impl/settings/stackit_vllm_settings.py`](diffhunk://#diff-a49520eb4e3694074ca6f4a688c512eca5fecad840367c5d7ad28a766fb3eed9L31-R32): Updated the default model from `"cortecs/Meta-Llama-3-70B-Instruct-GPTQ-8b"` to `"cortecs/Llama-3.3-70B-Instruct-FP8-Dynamic"` and changed the base URL to `"https://api.openai-compat.model-serving.eu01.onstackit.cloud/v1"` for improved compatibility and functionality.