### PR TITLE
refactor: update module type and file extensions in configuration files

### DIFF
--- a/services/frontend/libs/shared/utils/package.json
+++ b/services/frontend/libs/shared/utils/package.json
@@ -4,6 +4,6 @@
     "dependencies": {
         "tslib": "^2.3.0"
     },
-    "type": "commonjs",
-    "main": "./src/index.js"
+    "type": "module",
+    "main": "./src/index.ts"
 }

--- a/services/frontend/libs/shared/utils/src/index.ts
+++ b/services/frontend/libs/shared/utils/src/index.ts
@@ -1,5 +1,6 @@
-export * from './lib/date.utils.ts'
-export * from './lib/uuid.util.ts'
-export * from './lib/file-size-formatter.utils.ts'
-export * from './lib/marked.utils.ts'
-export * from './lib/is-empty.utils.ts'
+export * from './lib/date.utils'
+export * from './lib/file-size-formatter.utils'
+export * from './lib/is-empty.utils'
+export * from './lib/marked.utils'
+export * from './lib/uuid.util'
+

--- a/services/frontend/libs/shared/utils/tsconfig.json
+++ b/services/frontend/libs/shared/utils/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "extends": "../../../tsconfig.base.json",
     "compilerOptions": {
-        "module": "commonjs",
+        "module": "esnext",
         "forceConsistentCasingInFileNames": true,
         "strict": true,
         "noImplicitOverride": true,

--- a/services/frontend/tsconfig.base.json
+++ b/services/frontend/tsconfig.base.json
@@ -23,12 +23,12 @@
         "forceConsistentCasingInFileNames": true,
         "baseUrl": ".",
         "paths": {
-            "@chat": ["libs/chat-app/index"],
+            "@chat": ["libs/chat-app/index.ts"],
             "@admin": ["libs/admin-app/index"],
-            "@i18n/chat": ["libs/i18n/chat/index"],
+            "@i18n/chat": ["libs/i18n/chat/index.ts"],
             "@i18n/admin": ["libs/i18n/admin/index"],
-            "@shared/ui": ["libs/shared/ui/index"],
-            "@shared/utils": ["libs/shared/utils/src/index"],
+            "@shared/ui": ["libs/shared/ui/index.ts"],
+            "@shared/utils": ["libs/shared/utils/src/index.ts"],
             "@shared/style": ["libs/shared/global.css"]
         }
     },


### PR DESCRIPTION
This pull request updates the `services/frontend` project to adopt ES modules and TypeScript conventions more consistently. Key changes include switching from CommonJS to ES modules, updating file extensions in module paths, and removing unnecessary `.ts` extensions in import/export statements.

### Migration to ES modules:

* [`services/frontend/libs/shared/utils/package.json`](diffhunk://#diff-d64f34af5787aca8eb7a66b583933473526c15edc5cf6338d2c09f38ff7b2b7aL7-R8): Changed the `type` field from `commonjs` to `module` and updated the `main` field to point to `index.ts` instead of `index.js`.
* [`services/frontend/libs/shared/utils/tsconfig.json`](diffhunk://#diff-b4f2b54a18d6e55f43202d452b71ea8895bbff0cd789330f84ce5ff4a6eb6237L4-R4): Updated the `module` compiler option from `commonjs` to `esnext`.

### TypeScript file extension updates:

* [`services/frontend/libs/shared/utils/src/index.ts`](diffhunk://#diff-c292470fa6a226ffe1c183d3e1d9909a9e8b950746a66eb65027153975ca7a49L1-R6): Removed `.ts` extensions from import/export paths for better compatibility with ES modules.
* [`services/frontend/tsconfig.base.json`](diffhunk://#diff-ecb84aeedd2fa486fc966df39b040d031e6576ef6343bd30d2f4f31bcb76173aL26-R31): Updated paths to include `.ts` extensions for module resolution consistency.