### PR TITLE
fix: update log file paths and bump image tags to v2.0.0

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -163,6 +163,7 @@ docker_build(
         sync(core_library_context+"/rag-core-lib", "/app/libs/rag-core-lib"),
     ],
     dockerfile=backend_context + "/Dockerfile",
+    ignore=["infrastructure/"],
 )
 
 # Add linter trigger
@@ -202,6 +203,7 @@ docker_build(
         sync(mcp_context, "/app/services/mcp-server"),
     ],
     dockerfile=mcp_context + "/Dockerfile",
+    ignore=["infrastructure/"],
 )
 
 # Add linter trigger
@@ -236,6 +238,7 @@ docker_build(
         sync(core_library_context + "/admin-api-lib", "/app/libs/admin-api-lib"),
     ],
     dockerfile=admin_backend_context + "/Dockerfile",
+    ignore=["infrastructure/"],
 )
 
 # Add linter trigger
@@ -276,10 +279,10 @@ docker_build(
     },
     live_update=[
         sync(extractor_context, "/app/services/document-extractor"),
-        sync(core_library_context+"/rag-core-lib", "/app/libs/rag-core-lib"),
         sync(core_library_context +"/extractor-api-lib", "/app/libs/extractor-api-lib"),
         ],
     dockerfile=extractor_context + "/Dockerfile",
+    ignore=["infrastructure/"],
 )
 
 # Add linter trigger
@@ -314,7 +317,8 @@ docker_build(
     frontend_image_name,
     ".",
     dockerfile="./services/frontend/apps/chat-app/Dockerfile",
-    live_update=[sync("./services/frontend/apps/chat-app", "/app")],
+    live_update=[sync("./services/frontend", "/usr/src/app")],
+    ignore=["infrastructure/"],
 )
 
 ########################################################################################################################
@@ -327,7 +331,8 @@ docker_build(
     adminfrontend_image_name,
     ".",
     dockerfile="services/frontend/apps/admin-app/Dockerfile",
-    live_update=[sync("./services/frontend/apps/admin-app", "/app")],
+    live_update=[sync("./services/frontend", "/usr/src/app")],
+    ignore=["infrastructure/"],
 )
 
 

--- a/infrastructure/rag/templates/admin-backend/deployment.yaml
+++ b/infrastructure/rag/templates/admin-backend/deployment.yaml
@@ -34,11 +34,11 @@ spec:
           - sh
           - -c
           - |
-            touch /app/admin-backend/log/logfile.log && \
-            chmod 600 /app/admin-backend/log/logfile.log
+            touch /app/services/admin-backend/log/logfile.log && \
+            chmod 600 /app/services/admin-backend/log/logfile.log
         volumeMounts:
         - name: log-dir
-          mountPath: /app/admin-backend/log
+          mountPath: /app/services/admin-backend/log
       containers:
       - name: {{ .Values.adminBackend.name }}
         securityContext:
@@ -50,7 +50,7 @@ spec:
         - name: config-volume
           mountPath: /config
         - name: log-dir
-          mountPath: /app/admin-backend/log
+          mountPath: /app/services/admin-backend/log
         - name: tmp-dir
           mountPath: /tmp
         image: {{ template "adminBackend.fullImageName" . }}

--- a/infrastructure/rag/templates/backend/deployment.yaml
+++ b/infrastructure/rag/templates/backend/deployment.yaml
@@ -34,11 +34,11 @@ spec:
           - sh
           - -c
           - |
-            touch /app/rag-backend/log/logfile.log && \
-            chmod 600 /app/rag-backend/log/logfile.log
+            touch /app/services/rag-backend/log/logfile.log && \
+            chmod 600 /app/services/rag-backend/log/logfile.log
         volumeMounts:
         - name: log-dir
-          mountPath: /app/rag-backend/log
+          mountPath: /app/services/rag-backend/log
       containers:
       {{- if .Values.features.mcp.enabled }}
       - name: {{ .Values.backend.mcp.name }}
@@ -51,7 +51,7 @@ spec:
           - name: config-volume
             mountPath: /config
           - name: log-dir
-            mountPath: /app/mcp-server/log
+            mountPath: /app/services/mcp-server/log
       {{- end }}
       - name: {{ .Values.backend.name }}
         securityContext:
@@ -63,7 +63,7 @@ spec:
         - name: config-volume
           mountPath: /config
         - name: log-dir
-          mountPath: /app/rag-backend/log
+          mountPath: /app/services/rag-backend/log
         - name: tmp-dir
           mountPath: /tmp
         image: {{ include "backend.fullImageName" . }}

--- a/infrastructure/rag/templates/extractor/deployment.yaml
+++ b/infrastructure/rag/templates/extractor/deployment.yaml
@@ -36,15 +36,15 @@ spec:
           - sh
           - -c
           - |
-            touch /app/document-extractor/log/logfile.log && \
-            chmod 600 /app/document-extractor/log/logfile.log;
+            touch /app/services/document-extractor/log/logfile.log && \
+            chmod 600 /app/services/document-extractor/log/logfile.log;
             wget -q -O /tmp/punkt.zip https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/packages/tokenizers/punkt_tab.zip && \
             unzip /tmp/punkt.zip -d /home/nonroot/nltk_data/tokenizers && \
             wget -q -O /tmp/averaged_perceptron_tagger_eng.zip https://raw.githubusercontent.com/nltk/nltk_data/gh-pages/packages/taggers/averaged_perceptron_tagger_eng.zip && \
             unzip /tmp/averaged_perceptron_tagger_eng.zip -d /home/nonroot/nltk_data/taggers;
         volumeMounts:
         - name: log-dir
-          mountPath: /app/document-extractor/log
+          mountPath: /app/services/document-extractor/log
         - name: nltk-data-dir
           mountPath: /home/nonroot/nltk_data
         - name: tmp-dir
@@ -60,7 +60,7 @@ spec:
         - name: config-volume
           mountPath: /config
         - name: log-dir
-          mountPath: /app/document-extractor/log
+          mountPath: /app/services/document-extractor/log
         - name: tmp-dir
           mountPath: /tmp
         - name: nltk-data-dir

--- a/infrastructure/rag/values.yaml
+++ b/infrastructure/rag/values.yaml
@@ -24,7 +24,7 @@ backend:
       repository: ghcr.io/stackitcloud/rag-template
       name: rag-mcp
       pullPolicy: Always
-      tag: "v1.0.0"
+      tag: "v2.0.0"
 
   name: backend
   replicaCount: 1
@@ -33,7 +33,7 @@ backend:
     repository: ghcr.io/stackitcloud/rag-template
     name: rag-backend
     pullPolicy: Always
-    tag: "v1.0.0"
+    tag: "v2.0.0"
 
   command:
   - "poetry"
@@ -172,7 +172,7 @@ frontend:
     repository: ghcr.io/stackitcloud/rag-template
     name: frontend
     pullPolicy: Always
-    tag: "v1.0.0"
+    tag: "v2.0.0"
 
   service:
     type: ClusterIP
@@ -208,7 +208,7 @@ adminBackend:
     repository: ghcr.io/stackitcloud/rag-template
     name: admin-backend
     pullPolicy: Always
-    tag: "v1.0.0"
+    tag: "v2.0.0"
 
   command:
   - "poetry"
@@ -289,7 +289,7 @@ extractor:
     repository: ghcr.io/stackitcloud/rag-template
     name: document-extractor
     pullPolicy: Always
-    tag: "v1.0.0"
+    tag: "v2.0.0"
 
   command:
   - "poetry"
@@ -338,7 +338,7 @@ adminFrontend:
     repository: ghcr.io/stackitcloud/rag-template
     name: admin-frontend
     pullPolicy: Always
-    tag: "v1.0.0"
+    tag: "v2.0.0"
 
   service:
     type: ClusterIP


### PR DESCRIPTION
Correct log file paths and permissions in deployment configurations while updating all relevant image tags to version 2.0.0.