### PR TITLE
ci: add renovate action

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,161 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "timezone": "UTC",
+  "schedule": ["before 4am"],
+  "labels": ["renovate"],
+  "semanticCommits": "enabled",
+  "semanticCommitType": "chore",
+  "semanticCommitScope": "deps",
+  "prConcurrentLimit": 5,
+  "prHourlyLimit": 50,
+  "stabilityDays": 7,
+  "repositories": ["stackitcloud/rag-template"],
+  "hostRules": [
+    {
+      "hostType": "docker",
+      "matchHost": "ghcr.io"
+    },
+    {
+      "hostType": "helm",
+      "matchHost": "charts.bitnami.com"
+    },
+    {
+      "hostType": "helm",
+      "matchHost": "langfuse.github.io"
+    },
+    {
+      "hostType": "helm",
+      "matchHost": "qdrant.github.io"
+    },
+    {
+      "hostType": "helm",
+      "matchHost": "enapter.github.io"
+    },
+    {
+      "hostType": "helm",
+      "matchHost": "otwld.github.io"
+    }
+  ],
+
+  "packageRules": [
+    {
+      "description": "Group all non-major updates together",
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "groupName": "all non-major dependencies",
+      "groupSlug": "all-minor-patch"
+    },
+    {
+      "description": "Automerge non-major updates",
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true
+    },
+    {
+      "description": "Require manual review for major updates",
+      "matchUpdateTypes": ["major"],
+      "labels": ["major-update"],
+      "automerge": false
+    },
+    {
+      "description": "Label Python dependencies",
+      "matchManagers": ["poetry", "pip_requirements"],
+      "addLabels": ["python"]
+    },
+    {
+      "description": "Label Node.js dependencies",
+      "matchManagers": ["npm"],
+      "addLabels": ["nodejs"]
+    },
+    {
+      "description": "Label Docker images",
+      "matchManagers": ["dockerfile", "docker-compose"],
+      "addLabels": ["docker"]
+    },
+    {
+      "description": "Label Helm charts",
+      "matchManagers": ["helm-requirements", "helm-values", "helmv3"],
+      "addLabels": ["helm"]
+    },
+    {
+      "description": "Label Kubernetes manifests",
+      "matchManagers": ["kubernetes"],
+      "addLabels": ["kubernetes"]
+    },
+    {
+      "description": "Automerge GitHub Actions updates",
+      "matchManagers": ["github-actions"],
+      "addLabels": ["github-actions"],
+      "automerge": true
+    },
+    {
+      "description": "Ignore malformed platform flags",
+      "matchPackageNames": [
+        "--platform=linux/amd64 python",
+        "--platform=linux/amd64 node"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Bitnami Helm charts",
+      "matchManagers": ["helm-requirements", "helm-values", "helmv3"],
+      "matchPackageNames": ["minio", "bitnami/nginx-ingress-controller"],
+      "registryUrls": ["https://charts.bitnami.com/bitnami"]
+    },
+    {
+      "description": "Langfuse Helm chart",
+      "matchManagers": ["helm-requirements", "helm-values", "helmv3"],
+      "matchPackageNames": ["langfuse"],
+      "registryUrls": ["https://langfuse.github.io/langfuse-k8s"]
+    },
+    {
+      "description": "Qdrant Helm chart",
+      "matchManagers": ["helm-requirements", "helm-values", "helmv3"],
+      "matchPackageNames": ["qdrant"],
+      "registryUrls": ["https://qdrant.github.io/qdrant-helm"]
+    },
+    {
+      "description": "KeyDB Helm chart",
+      "matchManagers": ["helm-requirements", "helm-values", "helmv3"],
+      "matchPackageNames": ["keydb"],
+      "registryUrls": ["https://enapter.github.io/charts/"]
+    },
+    {
+      "description": "Ollama Helm chart",
+      "matchManagers": ["helm-requirements", "helm-values", "helmv3"],
+      "matchPackageNames": ["ollama"],
+      "registryUrls": ["https://otwld.github.io/ollama-helm/"]
+    }
+  ],
+  "customManagers": [
+    {
+      "description": "Update Helm chart versions in scripts",
+      "customType": "regex",
+      "fileMatch": ["\\.sh$"],
+      "matchStrings": [
+        "helm install .* --version \"(?<currentValue>.*?)\"",
+        "helm upgrade .* --version \"(?<currentValue>.*?)\""
+      ],
+      "datasourceTemplate": "helm",
+      "depNameTemplate": "bitnami/nginx-ingress-controller"
+    },
+    {
+      "description": "Update Docker image tags in Dockerfiles/scripts",
+      "customType": "regex",
+      "fileMatch": ["(^|/)Dockerfile$", "\\.sh$"],
+      "matchStrings": [
+        "FROM (?<depName>[^ :]+):(?<currentValue>[^@\\s]+)@sha256:",
+        "FROM (?<depName>[^ :]+):(?<currentValue>[^@\\s]+)\\s",
+        "docker.*(?<depName>[a-z0-9._-]+/[a-z0-9._-]+):(?<currentValue>[a-z0-9._-]+)"
+      ],
+      "datasourceTemplate": "docker"
+    }
+  ],
+  "ignoreDeps": [],
+  "ignorePaths": [
+    "**/node_modules/**",
+    "**/vendor/**",
+    "**/__pycache__/**",
+    "**/venv/**",
+    "**/.venv/**"
+  ]
+}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,40 @@
+name: Renovate
+
+on:
+  # Run monthly on the first day at 2 AM UTC
+  schedule:
+    - cron: '0 2 1 * *'
+  # Allow manual triggering
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'
+        required: false
+        default: 'info'
+        type: choice
+        options:
+          - info
+          - debug
+      dryRun:
+        description: 'Dry run'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  renovate:
+    name: Renovate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@v43.0.5
+        with:
+          configurationFile: .github/renovate.json
+          token: ${{ secrets.RENOVATE_TOKEN }}
+        env:
+          LOG_LEVEL: ${{ inputs.logLevel || 'info' }}
+          RENOVATE_DRY_RUN: ${{ inputs.dryRun || false }}
+          RENOVATE_BASE_BRANCH_PATTERNS: deps-main
+          TZ: Europe/Berlin

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,7 +1,6 @@
 name: Renovate
 
 on:
-  # Run monthly on the first day at 2 AM UTC
   schedule:
     - cron: '0 2 1 * *'
   # Allow manual triggering

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -311,8 +311,7 @@ backend:
     port: "8000" # Port on which the MCP server listens (default: 8000)
     host: "0.0.0.0" # Host address for the MCP server
     image:
-      repository: ghcr.io/stackitcloud/rag-template
-      name: rag-mcp
+      repository: ghcr.io/stackitcloud/rag-template/mcp-server
       pullPolicy: Always
       tag: "v1.0.0"
 ```

--- a/infrastructure/rag/templates/_admin_backend_and_extractor_helpers.tpl
+++ b/infrastructure/rag/templates/_admin_backend_and_extractor_helpers.tpl
@@ -74,11 +74,11 @@
 
 # image
 {{- define "adminBackend.fullImageName" -}}
-{{- printf "%s/%s:%s" .Values.adminBackend.image.repository .Values.adminBackend.image.name .Values.adminBackend.image.tag | trimSuffix ":" }}
+{{- printf "%s:%s" .Values.adminBackend.image.repository .Values.adminBackend.image.tag | trimSuffix ":" }}
 {{- end -}}
 
 {{- define "extractor.fullImageName" -}}
-{{- printf "%s/%s:%s" .Values.extractor.image.repository .Values.extractor.image.name .Values.extractor.image.tag | trimSuffix ":" }}
+{{- printf "%s:%s" .Values.extractor.image.repository .Values.extractor.image.tag | trimSuffix ":" }}
 {{- end -}}
 
 # ingress

--- a/infrastructure/rag/templates/_admin_frontend_helpers.tpl
+++ b/infrastructure/rag/templates/_admin_frontend_helpers.tpl
@@ -1,7 +1,7 @@
 {{- define "adminFrontend.fullImageName" -}}
 {{- if .Values.adminFrontend.image -}}
     {{- if .Values.adminFrontend.image.repository -}}
-        {{- printf "%s/%s:%s" .Values.adminFrontend.image.repository .Values.adminFrontend.image.name .Values.adminFrontend.image.tag | trimSuffix ":" }}
+        {{- printf "%s:%s" .Values.adminFrontend.image.repository .Values.adminFrontend.image.tag | trimSuffix ":" }}
     {{- else -}}
         {{ required "A valid .Values.adminFrontend.image.repository entry required!" . }}
     {{- end -}}

--- a/infrastructure/rag/templates/_backend_helpers.tpl
+++ b/infrastructure/rag/templates/_backend_helpers.tpl
@@ -95,11 +95,11 @@
 {{- end -}}
 
 {{- define "backend.fullImageName" -}}
-{{- printf "%s/%s:%s" .Values.backend.image.repository .Values.backend.image.name .Values.backend.image.tag | trimSuffix ":" | trimSuffix "-" }}
+{{- printf "%s:%s" .Values.backend.image.repository .Values.backend.image.tag | trimSuffix ":" | trimSuffix "-" }}
 {{- end -}}
 
 {{- define "mcp.fullImageName" -}}
-{{- printf "%s/%s:%s" .Values.backend.mcp.image.repository .Values.backend.mcp.image.name .Values.backend.mcp.image.tag | trimSuffix ":" | trimSuffix "-" }}
+{{- printf "%s:%s" .Values.backend.mcp.image.repository .Values.backend.mcp.image.tag | trimSuffix ":" | trimSuffix "-" }}
 {{- end -}}
 
 

--- a/infrastructure/rag/templates/_frontend_helpers.tpl
+++ b/infrastructure/rag/templates/_frontend_helpers.tpl
@@ -3,7 +3,7 @@
 {{- end -}}
 
 {{- define "frontend.fullImageName" -}}
-{{- printf "%s/%s:%s" .Values.frontend.image.repository .Values.frontend.image.name .Values.frontend.image.tag | trimSuffix ":" -}}
+{{- printf "%s:%s" .Values.frontend.image.repository .Values.frontend.image.tag | trimSuffix ":" -}}
 {{- end -}}
 
 {{- define "ingress.frontendFullname" -}}

--- a/infrastructure/rag/values.yaml
+++ b/infrastructure/rag/values.yaml
@@ -68,8 +68,7 @@ backend:
     chatWithHistoryExamples: ""
 
     image:
-      repository: ghcr.io/stackitcloud/rag-template
-      name: rag-mcp
+      repository: ghcr.io/stackitcloud/rag-template/mcp-server
       pullPolicy: Always
       tag: "v2.0.0"
 
@@ -77,8 +76,7 @@ backend:
   replicaCount: 1
 
   image:
-    repository: ghcr.io/stackitcloud/rag-template
-    name: rag-backend
+    repository: ghcr.io/stackitcloud/rag-template/rag-backend
     pullPolicy: Always
     tag: "v2.0.0"
 
@@ -216,8 +214,7 @@ frontend:
   name: frontend
   replicaCount: 1
   image:
-    repository: ghcr.io/stackitcloud/rag-template
-    name: frontend
+    repository: ghcr.io/stackitcloud/rag-template/frontend
     pullPolicy: Always
     tag: "v2.0.0"
 
@@ -252,8 +249,7 @@ adminBackend:
   name: admin-backend
 
   image:
-    repository: ghcr.io/stackitcloud/rag-template
-    name: admin-backend
+    repository: ghcr.io/stackitcloud/rag-template/admin-backend
     pullPolicy: Always
     tag: "v2.0.0"
 
@@ -333,8 +329,7 @@ extractor:
   replicaCount: 1
   name: extractor
   image:
-    repository: ghcr.io/stackitcloud/rag-template
-    name: document-extractor
+    repository: ghcr.io/stackitcloud/rag-template/document-extractor
     pullPolicy: Always
     tag: "v2.0.0"
 
@@ -382,8 +377,7 @@ adminFrontend:
   name: admin-frontend
   replicaCount: 1
   image:
-    repository: ghcr.io/stackitcloud/rag-template
-    name: admin-frontend
+    repository: ghcr.io/stackitcloud/rag-template/admin-frontend
     pullPolicy: Always
     tag: "v2.0.0"
 


### PR DESCRIPTION
This pull request introduces extensive updates to the repository, primarily focusing on enabling and configuring Renovate for dependency management and simplifying image repository structures across the infrastructure files. Key changes include adding Renovate configuration and workflow files, updating image repository paths, and streamlining Helm template logic.

### Renovate Integration:
* Added `.github/renovate.json` to configure Renovate with rules for dependency updates, grouping, automerging, and labeling. Custom managers and host rules for Helm charts and Docker images were also defined.
* Added `.github/workflows/renovate.yml` to schedule and manually trigger Renovate runs using a GitHub Actions workflow.

### Image Repository Updates:
* Updated image repository paths in `infrastructure/rag/values.yaml` for `backend`, `frontend`, `adminBackend`, `adminFrontend`, and `extractor` to use more specific paths (e.g., `ghcr.io/stackitcloud/rag-template/backend`). [[1]](diffhunk://#diff-673dd2d3d4e66a8fd4e45f9c1c9900711313f946bf8b6a89e96c954988fc14f3L71-R79) [[2]](diffhunk://#diff-673dd2d3d4e66a8fd4e45f9c1c9900711313f946bf8b6a89e96c954988fc14f3L219-R217) [[3]](diffhunk://#diff-673dd2d3d4e66a8fd4e45f9c1c9900711313f946bf8b6a89e96c954988fc14f3L255-R252) [[4]](diffhunk://#diff-673dd2d3d4e66a8fd4e45f9c1c9900711313f946bf8b6a89e96c954988fc14f3L336-R332) [[5]](diffhunk://#diff-673dd2d3d4e66a8fd4e45f9c1c9900711313f946bf8b6a89e96c954988fc14f3L385-R380)
* Updated the `backend` image repository in `infrastructure/README.md` to match the new path.

### Helm Template Simplification:
* Simplified Helm templates (`_admin_backend_and_extractor_helpers.tpl`, `_admin_frontend_helpers.tpl`, `_backend_helpers.tpl`, `_frontend_helpers.tpl`) by removing the `name` field from image definitions and adjusting the `printf` logic to construct the image name directly from `repository` and `tag`. [[1]](diffhunk://#diff-3ab40efdb049da16ac327c9fbaf8ec1d25f26efbeded4e0c2cfd7f50b976d3ceL77-R81) [[2]](diffhunk://#diff-d4bb1a3eee0baddaae66c8436788f842a4a323b8f4e872abed7bb131c293b5deL4-R4) [[3]](diffhunk://#diff-148b9880aef46deecdbc54ae7d004627e0aa1bf612fe139eb607861495ae9301L98-R102) [[4]](diffhunk://#diff-835710f9cf03927b5ee89d7846ddf62bd8b984af02ba75349500c65257c43934L6-R6)