### PR TITLE
ci: simplify semantic release

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -79,46 +79,6 @@ jobs:
             echo "ℹ️  No new release published"
           fi
 
-      - name: update-helm-values
-        if: steps.semantic-release.outputs.new-release-published == 'true'
-        run: |
-          echo "🔍 Debug: new-release-published = ${{ steps.semantic-release.outputs.new-release-published }}"
-          echo "🔍 Debug: new-release-version = ${{ steps.semantic-release.outputs.new-release-version }}"
-
-          NEW_VERSION="${{ steps.semantic-release.outputs.new-release-version }}"
-          VALUES_FILE="infrastructure/rag/values.yaml"
-
-          # Update Helm values using Python script
-          pip install ruamel.yaml
-          python3 tools/update-helm-values.py "$NEW_VERSION"
-
-          # Show git diff for verification
-          if ! git diff --quiet "$VALUES_FILE"; then
-            echo "Changes made to values.yaml:"
-            git diff "$VALUES_FILE"
-          else
-            echo "⚠️  No changes detected in values.yaml"
-          fi
-
-      - name: commit-helm-changes
-        if: steps.semantic-release.outputs.new-release-published == 'true'
-        run: |
-          # Check if there are changes to commit
-          if ! git diff --quiet infrastructure/rag/values.yaml; then
-            echo "📝 Committing Helm values changes..."
-            git config --local user.email "action@github.com"
-            git config --local user.name "GitHub Action"
-            git add infrastructure/rag/values.yaml
-
-            # Create a new commit for the Helm changes (don't amend since semantic-release already pushed)
-            git commit -m "chore: update helm chart image tags to v${{ steps.semantic-release.outputs.new-release-version }}"
-            git push
-
-            echo "✅ Helm chart changes committed and pushed"
-          else
-            echo "ℹ️  No Helm chart changes to commit"
-          fi
-
   build-and-push-images:
     name: build-and-push-images
     runs-on: ubuntu-latest
@@ -194,4 +154,3 @@ jobs:
           echo "- frontend" >> $GITHUB_STEP_SUMMARY
           echo "- admin-frontend" >> $GITHUB_STEP_SUMMARY
           echo "**Registry:** ghcr.io/${{ github.repository_owner }}/rag-template" >> $GITHUB_STEP_SUMMARY
-          echo "**Helm chart updated:** infrastructure/rag/values.yaml" >> $GITHUB_STEP_SUMMARY

--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,9 @@ IMAGE_TAG?=v1.0.0
 REGISTRY?=
 
 build_and_push:
-	docker buildx build --platform linux/amd64 -t $(REGISTRY)/rag-backend:$(IMAGE_TAG)  -f services/rag-backend/Dockerfile --push  .
-	docker buildx build --platform linux/amd64 -t $(REGISTRY)/admin-backend:$(IMAGE_TAG)  -f services/admin-backend/Dockerfile --push .
-	docker buildx build --platform linux/amd64 -t $(REGISTRY)/document-extractor:$(IMAGE_TAG)  -f services/document-extractor/Dockerfile --push .
-	docker buildx build --platform linux/amd64 -t $(REGISTRY)/frontend:$(IMAGE_TAG)  -f services/frontend/apps/chat-app/Dockerfile --push .
-	docker buildx build --platform linux/amd64 -t $(REGISTRY)/admin-frontend:$(IMAGE_TAG)  -f services/frontend/apps/admin-app/Dockerfile --push .
-	docker buildx build --platform linux/amd64 -t $(REGISTRY)/mcp-server:$(IMAGE_TAG)  -f services/mcp-server/Dockerfile --push .
+	docker buildx build --platform linux/amd64 -t $(REGISTRY)/rag-backend:$(IMAGE_TAG) -t $(REGISTRY)/rag-backend:latest -f services/rag-backend/Dockerfile --push  .
+	docker buildx build --platform linux/amd64 -t $(REGISTRY)/admin-backend:$(IMAGE_TAG) -t $(REGISTRY)/admin-backend:latest -f services/admin-backend/Dockerfile --push .
+	docker buildx build --platform linux/amd64 -t $(REGISTRY)/document-extractor:$(IMAGE_TAG) -t $(REGISTRY)/document-extractor:latest -f services/document-extractor/Dockerfile --push .
+	docker buildx build --platform linux/amd64 -t $(REGISTRY)/frontend:$(IMAGE_TAG) -t $(REGISTRY)/frontend:latest -f services/frontend/apps/chat-app/Dockerfile --push .
+	docker buildx build --platform linux/amd64 -t $(REGISTRY)/admin-frontend:$(IMAGE_TAG) -t $(REGISTRY)/admin-frontend:latest -f services/frontend/apps/admin-app/Dockerfile --push .
+	docker buildx build --platform linux/amd64 -t $(REGISTRY)/mcp-server:$(IMAGE_TAG) -t $(REGISTRY)/mcp-server:latest -f services/mcp-server/Dockerfile --push .

--- a/infrastructure/rag/values.yaml
+++ b/infrastructure/rag/values.yaml
@@ -70,7 +70,7 @@ backend:
     image:
       repository: ghcr.io/stackitcloud/rag-template/mcp-server
       pullPolicy: Always
-      tag: "v2.0.0"
+      tag: "latest"
 
   name: backend
   replicaCount: 1
@@ -78,7 +78,7 @@ backend:
   image:
     repository: ghcr.io/stackitcloud/rag-template/rag-backend
     pullPolicy: Always
-    tag: "v2.0.0"
+    tag: "latest"
 
   command:
   - "poetry"
@@ -216,7 +216,7 @@ frontend:
   image:
     repository: ghcr.io/stackitcloud/rag-template/frontend
     pullPolicy: Always
-    tag: "v2.0.0"
+    tag: "latest"
 
   service:
     type: ClusterIP
@@ -251,7 +251,7 @@ adminBackend:
   image:
     repository: ghcr.io/stackitcloud/rag-template/admin-backend
     pullPolicy: Always
-    tag: "v2.0.0"
+    tag: "latest"
 
   command:
   - "poetry"
@@ -331,7 +331,7 @@ extractor:
   image:
     repository: ghcr.io/stackitcloud/rag-template/document-extractor
     pullPolicy: Always
-    tag: "v2.0.0"
+    tag: "latest"
 
   command:
   - "poetry"
@@ -379,7 +379,7 @@ adminFrontend:
   image:
     repository: ghcr.io/stackitcloud/rag-template/admin-frontend
     pullPolicy: Always
-    tag: "v2.0.0"
+    tag: "latest"
 
   service:
     type: ClusterIP


### PR DESCRIPTION
This pull request updates the deployment pipeline and Helm configuration to streamline image tagging and simplify Helm chart updates. The main change is that all Docker images are now tagged with both the version and `latest`, and the Helm chart is updated to use the `latest` tag for all services. Additionally, the workflow steps that previously automated Helm value updates and commits have been removed, reflecting a shift to a simpler release process.

**Image Tagging and Helm Chart Updates:**

* Updated all Docker build commands in the `Makefile` to tag images with both the specific version and `latest`, ensuring the most recent build is always available under the `latest` tag.
* Changed the Helm values in `infrastructure/rag/values.yaml` for all services (`mcp-server`, `rag-backend`, `frontend`, `admin-backend`, `document-extractor`, `admin-frontend`) to use the `latest` image tag instead of a specific version. [[1]](diffhunk://#diff-673dd2d3d4e66a8fd4e45f9c1c9900711313f946bf8b6a89e96c954988fc14f3L73-R81) [[2]](diffhunk://#diff-673dd2d3d4e66a8fd4e45f9c1c9900711313f946bf8b6a89e96c954988fc14f3L219-R219) [[3]](diffhunk://#diff-673dd2d3d4e66a8fd4e45f9c1c9900711313f946bf8b6a89e96c954988fc14f3L254-R254) [[4]](diffhunk://#diff-673dd2d3d4e66a8fd4e45f9c1c9900711313f946bf8b6a89e96c954988fc14f3L334-R334) [[5]](diffhunk://#diff-673dd2d3d4e66a8fd4e45f9c1c9900711313f946bf8b6a89e96c954988fc14f3L382-R382)

**CI/CD Workflow Simplification:**

* Removed the `update-helm-values` and `commit-helm-changes` steps from `.github/workflows/semantic-release.yml`, so Helm values are no longer automatically updated and committed during release.
* Removed the summary line indicating the Helm chart was updated from the workflow output.