### PR TITLE
fix: update image name for mcp server in semantic release and Tiltfile

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -101,7 +101,7 @@ jobs:
             build-args: "dev=0"
           - name: mcp-server
             dockerfile: services/mcp-server/Dockerfile
-            image: rag-mcp
+            image: mcp-server
             build-args: "dev=0"
           - name: frontend
             dockerfile: services/frontend/apps/chat-app/Dockerfile

--- a/Tiltfile
+++ b/Tiltfile
@@ -189,7 +189,7 @@ local_resource(
 ################################## build mcp image and do live update ##################################################
 # NOTE: full image names should match the one in the helm chart values.yaml!
 registry = "ghcr.io/stackitcloud/rag-template"
-mcp_image_name = "rag-mcp"
+mcp_image_name = "mcp-server"
 
 mcp_context = "./services/mcp-server"
 mcp_full_image_name = "%s/%s" % (registry, mcp_image_name)


### PR DESCRIPTION
This pull request updates the naming convention for the MCP server Docker image to ensure consistency across the deployment workflow and local development configuration.

**Docker image naming consistency:**

* Changed the MCP server Docker image name from `rag-mcp` to `mcp-server` in the GitHub Actions workflow file `.github/workflows/semantic-release.yml` to match the actual service name.
* Updated the `Tiltfile` to use `mcp-server` as the image name for the MCP server, aligning it with the registry and Helm chart expectations.

fixes the following issue:

https://github.com/stackitcloud/rag-template/issues/81