### PR TITLE
fix: user id 2 allowed uid range in dockerfiles and deployment files.

### DIFF
--- a/infrastructure/rag/templates/admin-backend/deployment.yaml
+++ b/infrastructure/rag/templates/admin-backend/deployment.yaml
@@ -13,7 +13,7 @@ spec:
         app: {{ .Values.adminBackend.name }}
     spec:
       securityContext:
-        runAsUser: 65532
+        runAsUser: 10001
         runAsNonRoot: true
       volumes:
         - name: config-volume

--- a/infrastructure/rag/templates/backend/deployment.yaml
+++ b/infrastructure/rag/templates/backend/deployment.yaml
@@ -13,7 +13,7 @@ spec:
         app: {{ .Values.backend.name }}
     spec:
       securityContext:
-        runAsUser: 65532
+        runAsUser: 10001
         runAsNonRoot: true
       volumes:
         - name: config-volume

--- a/infrastructure/rag/templates/extractor/deployment.yaml
+++ b/infrastructure/rag/templates/extractor/deployment.yaml
@@ -13,7 +13,7 @@ spec:
         app: {{ .Values.extractor.name }}
     spec:
       securityContext:
-        runAsUser: 65532
+        runAsUser: 10001
         runAsNonRoot: true
       volumes:
         - name: config-volume

--- a/services/admin-backend/Dockerfile
+++ b/services/admin-backend/Dockerfile
@@ -29,7 +29,7 @@ RUN poetry config virtualenvs.create false && \
 FROM --platform=linux/amd64 python:3.13-bookworm
 ARG dev=0
 
-RUN adduser --disabled-password --gecos "" --uid 65532 nonroot
+RUN adduser --disabled-password --gecos "" --uid 10001 nonroot
 
 ENV POETRY_VIRTUALENVS_PATH=/app/services/admin-backend/.venv
 COPY --from=build --chown=nonroot:nonroot ${POETRY_VIRTUALENVS_PATH} ${POETRY_VIRTUALENVS_PATH}

--- a/services/document-extractor/Dockerfile
+++ b/services/document-extractor/Dockerfile
@@ -33,7 +33,7 @@ RUN poetry config virtualenvs.create false &&\
 FROM --platform=linux/amd64 python:3.13-bookworm
 ARG dev=0
 
-RUN adduser --disabled-password --gecos "" --uid 65532 nonroot
+RUN adduser --disabled-password --gecos "" --uid 10001 nonroot
 
 ENV POETRY_VIRTUALENVS_PATH=/app/services/document-extractor/.venv
 COPY --from=build  --chown=nonroot:nonroot ${POETRY_VIRTUALENVS_PATH} ${POETRY_VIRTUALENVS_PATH}

--- a/services/mcp-server/Dockerfile
+++ b/services/mcp-server/Dockerfile
@@ -29,7 +29,7 @@ RUN poetry config virtualenvs.create false &&\
 FROM --platform=linux/amd64 python:3.11.7-bookworm
 ARG dev=0
 
-RUN adduser --disabled-password --gecos "" --uid 65532 nonroot
+RUN adduser --disabled-password --gecos "" --uid 10001 nonroot
 
 ENV POETRY_VIRTUALENVS_PATH=/app/services/mcp-server/.venv
 COPY --from=build --chown=nonroot:nonroot ${POETRY_VIRTUALENVS_PATH} ${POETRY_VIRTUALENVS_PATH}

--- a/services/rag-backend/Dockerfile
+++ b/services/rag-backend/Dockerfile
@@ -31,7 +31,7 @@ RUN poetry config virtualenvs.create false &&\
 FROM --platform=linux/amd64 python:3.13-bookworm
 ARG dev=0
 
-RUN adduser --disabled-password --gecos "" --uid 65532 nonroot
+RUN adduser --disabled-password --gecos "" --uid 10001 nonroot
 
 ENV POETRY_VIRTUALENVS_PATH=/app/services/rag-backend/.venv
 COPY --from=build --chown=nonroot:nonroot ${POETRY_VIRTUALENVS_PATH} ${POETRY_VIRTUALENVS_PATH}


### PR DESCRIPTION
This pull request updates the user ID used for running application containers and deployments from `65532` to `10001` across several services and infrastructure templates. This change helps ensure consistency and avoids warning that the user id is out of range (min/max ID)

**Container user ID standardization:**

* Updated the `RUN adduser` command in the Dockerfiles for `admin-backend`, `document-extractor`, `mcp-server`, and `rag-backend` services to use UID `10001` instead of `65532`. [[1]](diffhunk://#diff-cf35870e15ed0be6a47ea55d8edbb761fe538d085e1a53908e520657ac60728bL32-R32) [[2]](diffhunk://#diff-155cd6a0b0260ebd5083f558ad74efaad1df57c35fccd00a474f07387b61bb0eL36-R36) [[3]](diffhunk://#diff-319d5d10288f846604056f8343b020d8f594d75ae6ec68fd4b4cf93d3cc446ebL32-R32) [[4]](diffhunk://#diff-7c465da557b2ce2393e237866279cf981aa92aea5c412fa7ecb66afc6db00fb6L34-R34)

**Kubernetes deployment configuration:**

* Changed the `runAsUser` value in the `securityContext` of the deployment templates for `admin-backend`, `backend`, and `extractor` to `10001` instead of `65532`. [[1]](diffhunk://#diff-2b6f7f2ec4938055207faa53acf7a300e0ec235db31d1cfb6896703b97292348L16-R16) [[2]](diffhunk://#diff-9f487482fa54d28d71fff497724bbc6741cced8a1e35c9b8829d1c6bd01dca0aL16-R16) [[3]](diffhunk://#diff-289e7e7aa5f8a10603dafc1c094fa3487201006a7d5429a0dd9c6c80b3426fcfL16-R16)