### PR TITLE
fix: remove unused max_pages parameter from confluence loader parameters

### DIFF
--- a/libs/extractor-api-lib/src/extractor_api_lib/impl/extractors/confluence_extractor.py
+++ b/libs/extractor-api-lib/src/extractor_api_lib/impl/extractors/confluence_extractor.py
@@ -54,6 +54,11 @@ class ConfluenceExtractor(InformationExtractor):
         confluence_loader_parameters = {
             x.key: int(x.value) if x.value.isdigit() else x.value for x in extraction_parameters.kwargs
         }
+        if (
+            not confluence_loader_parameters.get("max_pages")
+            or isinstance(confluence_loader_parameters.get("max_pages"), str)
+        ):
+            confluence_loader_parameters.pop("max_pages")
         # Drop the document_name parameter as it is not used by the ConfluenceLoader
         if "document_name" in confluence_loader_parameters:
             confluence_loader_parameters.pop("document_name", None)

--- a/libs/extractor-api-lib/src/extractor_api_lib/impl/extractors/confluence_extractor.py
+++ b/libs/extractor-api-lib/src/extractor_api_lib/impl/extractors/confluence_extractor.py
@@ -1,5 +1,6 @@
 """Module for the DefaultConfluenceExtractor class."""
 
+import logging
 from langchain_community.document_loaders import ConfluenceLoader
 
 from extractor_api_lib.impl.types.extractor_types import ExtractorTypes
@@ -9,6 +10,8 @@ from extractor_api_lib.extractors.information_extractor import InformationExtrac
 from extractor_api_lib.impl.mapper.confluence_langchain_document2information_piece import (
     ConfluenceLangchainDocument2InformationPiece,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class ConfluenceExtractor(InformationExtractor):
@@ -57,6 +60,9 @@ class ConfluenceExtractor(InformationExtractor):
         if not confluence_loader_parameters.get("max_pages") or isinstance(
             confluence_loader_parameters.get("max_pages"), str
         ):
+            logging.warning(
+                "max_pages parameter is not set or invalid discarding it. ConfluenceLoader will use default value."
+            )
             confluence_loader_parameters.pop("max_pages")
         # Drop the document_name parameter as it is not used by the ConfluenceLoader
         if "document_name" in confluence_loader_parameters:

--- a/libs/extractor-api-lib/src/extractor_api_lib/impl/extractors/confluence_extractor.py
+++ b/libs/extractor-api-lib/src/extractor_api_lib/impl/extractors/confluence_extractor.py
@@ -54,9 +54,8 @@ class ConfluenceExtractor(InformationExtractor):
         confluence_loader_parameters = {
             x.key: int(x.value) if x.value.isdigit() else x.value for x in extraction_parameters.kwargs
         }
-        if (
-            not confluence_loader_parameters.get("max_pages")
-            or isinstance(confluence_loader_parameters.get("max_pages"), str)
+        if not confluence_loader_parameters.get("max_pages") or isinstance(
+            confluence_loader_parameters.get("max_pages"), str
         ):
             confluence_loader_parameters.pop("max_pages")
         # Drop the document_name parameter as it is not used by the ConfluenceLoader


### PR DESCRIPTION
This pull request introduces an improvement to the handling of the `max_pages` parameter in the Confluence extractor. The update ensures that the parameter is only included if it is properly set and of the correct type, which helps prevent potential issues when passing parameters to the `ConfluenceLoader`.

Parameter handling improvements:

* In `extractors/confluence_extractor.py`, the code now removes the `max_pages` parameter from `confluence_loader_parameters` if it is missing or is a string, ensuring only valid integer values are passed to the loader.

This PR fixes following issue:
https://github.com/stackitcloud/rag-template/issues/85