### PR TITLE
refactor: Change RENOVATE_BASE_BRANCH_PATTERNS to 'main'

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -35,5 +35,5 @@ jobs:
         env:
           LOG_LEVEL: ${{ inputs.logLevel || 'info' }}
           RENOVATE_DRY_RUN: ${{ inputs.dryRun || false }}
-          RENOVATE_BASE_BRANCH_PATTERNS: deps-main
+          RENOVATE_BASE_BRANCH_PATTERNS: main
           TZ: Europe/Berlin


### PR DESCRIPTION
This pull request makes a minor update to the Renovate GitHub Actions workflow configuration. The base branch pattern for Renovate has been changed from `deps-main` to `main` to ensure that Renovate operates on the correct branch.

* Changed the `RENOVATE_BASE_BRANCH_PATTERNS` environment variable in `.github/workflows/renovate.yml` from `deps-main` to `main`.