### PR TITLE
chore: rename codex instructions

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -1,5 +1,4 @@
-# .github/codex-instructions.md
-
+# AGENTS.md
 > **Scope:** These instructions tune our **Codex** code-generation agent (LLM via API/CLI) for this monorepo. They are **authoritative**: follow them over generic best practices. Output must compile, pass linters/tests, and fit our structure.
 
 ---


### PR DESCRIPTION
This pull request includes a minor documentation update. The `.github/codex-instructions.md` file was renamed to `.codex/AGENTS.md`, and the introductory section was slightly revised for clarity. No functional or code changes were made.