### PR TITLE
chore: Update appVersion format in Chart.yaml

### DIFF
--- a/infrastructure/rag/Chart.yaml
+++ b/infrastructure/rag/Chart.yaml
@@ -6,7 +6,7 @@ description: |
   ask question about their content and the rag will answer them.
 type: application
 version: 3.4.0
-appVersion: "3.4.0"
+appVersion: "v3.4.0"
 dependencies:
 - name: langfuse
   repository: https://langfuse.github.io/langfuse-k8s


### PR DESCRIPTION
This pull request makes a minor update to the `infrastructure/rag/Chart.yaml` file, changing the format of the `appVersion` value to include a "v" prefix.

* Changed `appVersion` from `"3.4.0"` to `"v3.4.0"` in `Chart.yaml`."