### PR TITLE
chore: add timeoutSeconds to startupProbe in frontend deployments

### DIFF
--- a/infrastructure/rag/templates/frontend/admin-deployment.yaml
+++ b/infrastructure/rag/templates/frontend/admin-deployment.yaml
@@ -28,6 +28,7 @@ spec:
             - /bin/sh
             - "-c"
             - "cp -r /app/frontend/. /usr/share/nginx/html && /bin/sh /app/env.sh"
+          timeoutSeconds: 30
         securityContext:
           runAsUser: 101
           runAsNonRoot: true

--- a/infrastructure/rag/templates/frontend/deployment.yaml
+++ b/infrastructure/rag/templates/frontend/deployment.yaml
@@ -28,6 +28,7 @@ spec:
             - /bin/sh
             - "-c"
             - "cp -r /app/frontend/. /usr/share/nginx/html && /bin/sh /app/env.sh"
+          timeoutSeconds: 30
         securityContext:
           runAsUser: 101
           runAsNonRoot: true


### PR DESCRIPTION
This pull request introduces a configuration update to the frontend deployment templates for both the admin and standard environments. The main change is the addition of a timeout setting for the container's startup command to improve reliability during initialization.

Deployment configuration improvements:

* Added `timeoutSeconds: 30` to the `spec` of both `frontend/admin-deployment.yaml` and `frontend/deployment.yaml` to ensure the container startup command does not hang indefinitely. [[1]](diffhunk://#diff-ae3526cd10da0d852bc4edebe138754c3e5999fd27f3cc188e04b3edc4d914ebR31) [[2]](diffhunk://#diff-ff608e04ebc1c467eaa947889a290db2717a17758c34255049347a364076cce3R31)