### PR TITLE
ci: Update publish-chart-packages.yml to add .gitignore

### DIFF
--- a/.github/workflows/publish-chart-packages.yml
+++ b/.github/workflows/publish-chart-packages.yml
@@ -119,6 +119,11 @@ jobs:
           fi
           echo "Index generated for $BASE_URL"
 
+      - name: Allow chart archives in gh-pages
+        run: |
+          set -euo pipefail
+          printf "%s\n" ".DS_Store" > dist/.gitignore
+
       - name: Publish Helm repo to gh-pages
         uses: peaceiris/actions-gh-pages@v4
         with:


### PR DESCRIPTION
This pull request makes a minor update to the Helm chart publishing workflow by adding a `.gitignore` file to the `dist` directory. This change ensures that `.DS_Store` files are ignored when publishing chart archives to the `gh-pages` branch.