### PR TITLE
docs: add missing readme.md to fix dependabot python resolution

### DIFF
--- a/services/rag-backend/README.md
+++ b/services/rag-backend/README.md
@@ -1,0 +1,18 @@
+# RAG backend
+
+The RAG backend provides the chat and retrieval API for the template. It uses
+the shared RAG libraries to connect uploaded content, embeddings, vector
+storage, and language model calls.
+
+# Requirements
+
+All required Python libraries can be found in the [pyproject.toml](pyproject.toml)
+file. The backend ships its own `Dockerfile` and `Dockerfile.dev` and depends on
+the [rag-core-api](../../libs/rag-core-api/) and
+[rag-core-lib](../../libs/rag-core-lib/) packages.
+
+# Deployment
+
+A detailed explanation of the deployment can be found in the
+[project README](../../README.md). The Helm chart used for deployment is in the
+[infrastructure directory](../../infrastructure/).


### PR DESCRIPTION
This pull request adds initial documentation for the `rag-backend` service, outlining its purpose, dependencies, and deployment instructions.

Documentation updates:

* Added a new `README.md` file for the `rag-backend` service, describing its functionality, required libraries, Docker setup, dependencies on shared RAG libraries, and providing links to deployment instructions and Helm charts.