### PR TITLE
ci(fix): avoid duplicate release authentication

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -60,6 +60,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -102,7 +103,7 @@ jobs:
           python tools/bump_pyproject_deps.py --version "${{ steps.semrel.outputs.version }}" --bump-libs
 
       - name: Commit and open PR
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           branch: chore/release-${{ steps.semrel.outputs.version }}
           title: "chore(release): prepare ${{ steps.semrel.outputs.version }}"

--- a/.github/workflows/promote-clean-semver.yml
+++ b/.github/workflows/promote-clean-semver.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ inputs.ref || 'main' }}
+          persist-credentials: false
 
       - name: Load version metadata (workflow_run)
         if: ${{ github.event_name == 'workflow_run' }}
@@ -188,7 +189,7 @@ jobs:
 
       - name: Open PR with updated locks, pins, and Chart appVersion
         id: cpr
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           branch: chore/refresh-locks-${{ steps.versions.outputs.clean_version }}-${{ github.run_number }}
           title: "chore(release): refresh service lockfiles for ${{ steps.versions.outputs.clean_version }}"


### PR DESCRIPTION
This pull request updates workflow configuration files to improve security and keep dependencies up to date. The main changes are upgrading the `peter-evans/create-pull-request` GitHub Action to the latest major version and disabling credential persistence during repository checkout steps.

**GitHub Actions improvements:**

* Upgraded `peter-evans/create-pull-request` from version 6 to version 8 in both `.github/workflows/prepare-release.yml` and `.github/workflows/promote-clean-semver.yml` to ensure the latest features and security updates are used. [[1]](diffhunk://#diff-ddf2bab74923dcd43f9f8d05e50bb1adc9ee5366a394d151d1f04a54a6079486L105-R106) [[2]](diffhunk://#diff-565eb0e1b0e3b91e82f7cf1ee64348f5102387ff136a8241b0d479198c6e8aa4L191-R192)
* Set `persist-credentials: false` in all `actions/checkout` steps to prevent GitHub Actions from persisting repository credentials, which improves workflow security. [[1]](diffhunk://#diff-ddf2bab74923dcd43f9f8d05e50bb1adc9ee5366a394d151d1f04a54a6079486R63) [[2]](diffhunk://#diff-565eb0e1b0e3b91e82f7cf1ee64348f5102387ff136a8241b0d479198c6e8aa4R37)